### PR TITLE
Adding command to concatenate keys

### DIFF
--- a/Installing-Heads.md
+++ b/Installing-Heads.md
@@ -82,6 +82,7 @@ for this Yubikey (the secret key lives only in the Yubikey).
 ```
 gpg --homedir=/media/gnupg/ --export -a > /media/gnupg/public.key
 gpg --homedir=/media/gnupg/ --export-secret-keys -a > /media/gnupg/private_stub.key
+cat /media/gnupg/private_stub.key /media/gnupg/public.key > /media/gnupg/concatenated.key
 ```
 
 Adding your PGP key


### PR DESCRIPTION
Previous text refers to creating a single file containing both private_stub and public key but never indicated how.

I successfully generated the keys from fedora-28 with gpg2 --card-edit. Couldn't with gpg (1.4.24) from fedora-28. Generating armor copies of the keys worked with gpg2 commands.

Note: I was not able to use cbfs commands of the following section and have a working head environment. I still can't figure what I did wrong. This needs to be tested more. using gui-init and integrating the keys into running/referenced roms worked out of the box with keys concatenated.