### PR TITLE
Adding gcc-gnat for Fedora build instructions

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -33,7 +33,7 @@ On a Fedora machine:
 ```
 dnf install -y \
 	@development-tools \
-	gcc-c++ zlib-devel perl-Digest-MD5 perl-Digest-SHA \
+	gcc-c++ gcc-gnat zlib-devel perl-Digest-MD5 perl-Digest-SHA \
 	uuid-devel pcsc-tools qemu ncurses-devel lbzip2 \
 	libuuid-devel lzma \
 	elfutils-libelf-devel \


### PR DESCRIPTION
gcc-gnat is required to build native graphic initialization for intel boards.