### PR TITLE
Adding get_blobs.sh Fedora requirements

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -50,7 +50,9 @@ dnf install -y \
 	python \
 	wget \
 	libusb-devel \
-	cmake
+	cmake \
+	pv \
+	bsdiff
 
 # For emulation and analysis with UEFITool
 dnf install -y \


### PR DESCRIPTION
bsdiff and pv are required in the script