### PR TITLE
Add pkg-config to required Debian dependencies

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -26,7 +26,8 @@ apt install -y \
 	wget \
 	gnat \
 	cpio \
-	ccache
+	ccache \
+	pkg-config
 ```
 
 On a Fedora machine:


### PR DESCRIPTION
I was attempting to build Heads from current git master, but the build failed here:

```
2019-02-19 00:08:45+00:00 CONFIG cairo
make[1]: *** [Makefile:356: /root/heads/build/cairo-1.14.12/.configured] Error 1
make[1]: Leaving directory '/root/heads'
Makefile:561: recipe for target 'all' failed
make: *** [all] Error 2
```

Looking at the build log for cairo, I found this:

```
checking for i386-elf-linux-pkg-config... no
checking for pkg-config... no
configure: error: pkg-config >=  required but not found (http://pkgconfig.freedesktop.org/)
```

I ran into this error on both Debian 9 and Ubuntu 16.04 (LXC images from linuxcontainers.org). The build ran successfully after installing pkg-config. I'm not sure if bare-metal distro images would have it preinstalled, but the LXC images at least do not.