### PR TITLE
add texinfo to debian package list

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -31,6 +31,7 @@ apt install -y \
 	cmake \
 	libusb-1.0-0-dev \
 	pkg-config \
+	texinfo \
 ```
 
 On a Fedora machine:


### PR DESCRIPTION
tested on both debian9 and ubuntu 19.10, this package isn't part of the default sets so should be added