### PR TITLE
PCR documentation usage changes for coreboot 4.8.1 and newer versions

### DIFF
--- a/Keys.md
+++ b/Keys.md
@@ -98,7 +98,7 @@ The actual assignment needs to be updated in the code; there are outstanding iss
 
 1: Nothing for the moment
 
-2: Boot block, ROM stage, RAM stage, Heads linux kernel and initrd (and MRC? this should be separate)
+2: Boot block, ROM stage, RAM stage, Heads linux kernel and initrd
 
 3: Nothing for the moment
 

--- a/Keys.md
+++ b/Keys.md
@@ -94,13 +94,13 @@ The actual assignment needs to be updated in the code; there are outstanding iss
 [SMM reloc](https://github.com/osresearch/heads/issues/13)
 ) that need to be resolved as well.  Until then this is a rough draft of how Heads uses the TPM PCRs.
 
-0: Boot block
+0: Nothing for the moment
 
-1: ROM stage
+1: Nothing for the moment
 
-2: RAM stage (and MRC? this should be separate)
+2: Boot block, ROM stage, RAM stage, Heads linux kernel and initrd (and MRC? this should be separate)
 
-3: Heads Linux kernel and initrd
+3: Nothing for the moment
 
 4: Boot mode (0 during `/init`, then `recovery` or `normal-boot`)
 


### PR DESCRIPTION
Documentation changes linked to PCR usage in coreboot 4.8.1 and newer versions, to be applied at the same time as https://github.com/osresearch/heads/pull/793 is merged.
Linked to VBOOT+Measured boot/Measured boot changes applied directly in coreboot so that we have a common base prior of going https://github.com/osresearch/heads/pull/709 and https://github.com/osresearch/heads/pull/721 

@PatrickRudolph comments welcome