### PR TITLE
fix(config.yml): change gh_edit_branch to master

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,5 +15,5 @@ last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https:/
 gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub."
 gh_edit_repository: "//github.com/osresearch/heads-wiki"
-gh_edit_branch: "gh-pages"
+gh_edit_branch: "master"
 gh_edit_view_mode: "edit"


### PR DESCRIPTION
Checking out the updated theme for the head wiki and noticed the "Edit this page on Github" links are pointing to the gh-pages branch instead of master.