### PR TITLE
Split up 'Building Heads' with board specifics

### DIFF
--- a/Installing-and-Configuring/Building-Heads/general.md
+++ b/Installing-and-Configuring/Building-Heads/general.md
@@ -1,9 +1,10 @@
 ---
 layout: default
-title: Step 1 - Building Heads
-permalink: /Building/
+title: General Building
 nav_order: 1
-parent: Installing and configuring
+permalink: /general-building/
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
 ---
 
 <!-- markdownlint-disable MD033 -->
@@ -87,51 +88,6 @@ Generally, everything that is needed to flash the SPI flash of a board is a
  The resulting rom file will be either `./build/XXX/XXX.rom` or
   `./build/XXX/coreboot.rom` (`XXX` should be the name of your board in
   `./boards`).
-
-Make for a specific configuration
----
-
-Some boards have a two SPI flash chip configuration and need special care.
-
-x230
-----
-
-For the Thinkpad x230 there are two boards in `./boards`, x230-flash and x230.
- x230-flash is externally flashable and contains a smaller package that will
- let us boot to the Heads recovery shell. x230 is only internally flashable and
- contains all of Heads. Since we will end up using both x230-flash and x230, it
- makes the most sense to build both now.
-
-Initial SPI2 (4MB) flash chip
------
-
-x230 boards needs their 4MB SPI2 to be initially externally flashed,
- while the 12MB rom needs to be flashed internally from within Heads to make
- sure to not screw up with ME, contained in the SPI1 flash (8MB bottom flash
- chip under keyboard)
-
-The following make command generates a self-contained, externally flashable rom
- for the SPI2 (4MB BIOS, top SPI flash under keyboard).
-
-```Makefile
-make BOARD=x230-flash
-```
-
-Resulting rom is found under build/x230-flash/x230-flash.rom
-
-Subsequent flashing (upgrades)
------
-
-The following make command will generate a 12MB `coreboot.rom` under the
-build/x230 directory.
-
-```Makefile
-make BOARD=x230
-```
-
-The `coreboot.rom` is the one needed to flash rom updates from within Heads in
-respect of ME. This is done with the help of the `flashrom-x230.sh` script from
-Heads recovery shell.
 
 Please continue to the corresponding flashing guide for your device.
 

--- a/Installing-and-Configuring/Building-Heads/index.md
+++ b/Installing-and-Configuring/Building-Heads/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Step 1 - Building Heads
+permalink: /Building/
+nav_order: 1
+parent: Installing and configuring
+has_children: yes
+---
+

--- a/Installing-and-Configuring/Building-Heads/kgpe-d16.md
+++ b/Installing-and-Configuring/Building-Heads/kgpe-d16.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Asus KGPE-D16
+permalink: /kgpe-d16-building/
+nav_order: 1
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+Asus KGPE-D16
+====
+
+TO BE WRITTEN

--- a/Installing-and-Configuring/Building-Heads/t420.md
+++ b/Installing-and-Configuring/Building-Heads/t420.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Lenovo T420
+nav_order: 1
+permalink: /t420-building/
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+Lenovo T420
+=====
+
+TO BE WRITTEN

--- a/Installing-and-Configuring/Building-Heads/t430.md
+++ b/Installing-and-Configuring/Building-Heads/t430.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Lenovo T430
+nav_order: 1
+permalink: /t430-building/
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+Lenovo T430
+====
+
+TO BE WRITTEN

--- a/Installing-and-Configuring/Building-Heads/x220.md
+++ b/Installing-and-Configuring/Building-Heads/x220.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Lenovo X220
+nav_order: 1
+permalink: /x220-building/
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+# Lenovo X220
+
+TO BE WRITTEN

--- a/Installing-and-Configuring/Building-Heads/x230.md
+++ b/Installing-and-Configuring/Building-Heads/x230.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: Lenovo X230
+permalink: /x230-building/
+nav_order: 1
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+Lenovo X230
+====
+
+For the Thinkpad x230 there are two boards in `./boards`, x230-flash and x230.
+ x230-flash is externally flashable and contains a smaller package that will
+ let us boot to the Heads recovery shell. x230 is only internally flashable and
+ contains all of Heads. Since we will end up using both x230-flash and x230, it
+ makes the most sense to build both now.
+
+Initial SPI2 (4MB) flash chip
+-----
+
+x230 boards needs their 4MB SPI2 to be initially externally flashed,
+ while the 12MB rom needs to be flashed internally from within Heads to make
+ sure to not screw up with ME, contained in the SPI1 flash (8MB bottom flash
+ chip under keyboard)
+
+The following make command generates a self-contained, externally flashable rom
+ for the SPI2 (4MB BIOS, top SPI flash under keyboard).
+
+```Makefile
+make BOARD=x230-flash
+```
+
+Resulting rom is found under build/x230-flash/x230-flash.rom
+
+Subsequent flashing (upgrades)
+-----
+
+The following make command will generate a 12MB `coreboot.rom` under the
+build/x230 directory.
+
+```Makefile
+make BOARD=x230
+```
+
+The `coreboot.rom` is the one needed to flash rom updates from within Heads in
+respect of ME. This is done with the help of the `flashrom-x230.sh` script from
+Heads recovery shell.
+
+Please continue to the [flashing guide](/x230-flashing/)
+
+More options and detail about Heads modules under [Makefile](/Makefile/)


### PR DESCRIPTION
Can be viewed: [https://tonux599.github.io/heads-wiki/](https://tonux599.github.io/heads-wiki/)

Commit message outlines:
> Split up 'Step 1 - Building Heads' as it had references to the X230 board in it's main guide. This split has moved general information into 'General Building' and X230 specific to 'Lenovo X230' while keeping it all under the same 'Step 1 - Building Heads' heading. Template/WIP pages for some other boards.

If everyone is happy with this and its merged. I can base my upcoming KGPE-D16 docs on it.