### PR TITLE
Firmware download/upgrade/prerequisites cleanup 

### DIFF
--- a/About/Keys.md
+++ b/About/Keys.md
@@ -174,17 +174,11 @@ TPM PCRs
 
 ![TPM]({{ site.baseurl }}/images/TPM.jpg)
 
-The actual assignment needs to be updated in the code; there are outstanding
- issues ([MRC cache](https://github.com/osresearch/heads/issues/150),
- [SMM reloc](https://github.com/osresearch/heads/issues/13)
- ) that need to be resolved as well.  Until then this is a rough draft of how
- Heads uses the TPM PCRs.
-
-0: Nothing for the moment
+0: Nothing for the moment (Populated by binary blobs where applicable for [DRTM](https://doc.coreboot.org/security/vboot/measured_boot.html#ibb-crtm))
 
 1: Nothing for the moment
 
-2: Boot block, ROM stage, RAM stage, Heads linux kernel and initrd
+2: coreboot's Boot block, ROM stage, RAM stage, Payload (Heads linux kernel and initrd)
 
 3: Nothing for the moment
 
@@ -194,15 +188,55 @@ The actual assignment needs to be updated in the code; there are outstanding
 
 6: Drive LUKS headers
 
-7: Heads user-specific config files
+7: Heads user-specific files stored in CBFS (config.user, GPG keyring, etc).
+
+Some history
+---
+Heads relied on coreboot patches until coreboot 4.8.1 for measured boot 
+implementation, since coreboot had none.
+Heads measured boot scheme [changed](https://github.com/osresearch/heads/pull/793) to match coreboot 4.12's, which for the first time included seperated measured boot implementation from vboot implementation.
+
+Since coreboot 4.12, Heads stopped patching coreboot to implement measured boot. 
+coreboot measured boot implementation is the one filling PCR2, above.
+
+Heads since then solely extends PCRs of it's own (PCRs 4-5-6-7 above) which are used when 
+sealing/unsealing. 
+
+As you can see above, coreboot measures itself from bootblock then other boot phases up to its
+payload in PCR2, in conformity of their [SRTM](https://doc.coreboot.org/security/vboot/measured_boot.html#srtm-mode) measured boot policy.
+An example is given from [coreboot docs](https://doc.coreboot.org/security/vboot/measured_boot.html#platform-configuration-register).
+
+TPM_Unseal errors
+---
+Consequently, if either coreboot phases, boot mode, kernel modules, LUKS headers
+or CBFS files are different then when those measurements were used to seal secrets, 
+unseal operations will fail. HOTP/TOTP/TPM Disk Unlock Key passphrase should give errors
+in case of tempering. 
+
+The TPM Disk Unlock Key passphrase would fail with a different error then: 
+`Error Authentication failed (Incorrect Password) from TPM_Unseal` when  a user types
+a [TPM Disk Unlock key passphrase](/Keys/#disk-unlock-key-passphrase-prompt-output).
+ 
+Indeed, the PCRs measurements used to seal the Disk Unlock Key in TPM NV memory cannot unseal 
+that secret, even with a good TPM Disk Unlock Key passphrase, while HOTP/TOTP should not be able
+to unseal either.
+ 
+
+TCPA Event log
+---
+From the [Recovery Shell](/Recovery), it is possible to review PCR2 [TCPA event log](https://doc.coreboot.org/security/vboot/measured_boot.html#tcpa-eventlog) by typing:
+`cbmem -L`
+
 
 Disk Unlock Key passphrase prompt output
 ==== 
 ![Disk Unlock Key passphrase showed PCRs when passphrase fails](https://user-images.githubusercontent.com/827570/82279087-b2da2000-9959-11ea-8020-6ff36e947576.jpeg)
 
-Here you can see that "Boot block, ROM stage, RAM stage, Heads linux kernel and initrd", "Drive LUKS headers" and "Heads user-specific config files" have filled the registers PCR-02, PCR-06 and PCR-07 respectively. You can also see the TPM returning the error "Error Authentication failed (Incorrect Password)" which is an invitation to try again, this time typing more slowly. 
+Here you can see that "Boot block, ROM stage, RAM stage, Heads payload", "Drive LUKS headers" and "Heads user-specific config files" have filled the registers PCR-02, PCR-06 and PCR-07 respectively. You can also see the TPM returning the error "Error Authentication failed (Incorrect Password)" which is an invitation to try again, this time typing more slowly. Measurements are consistent to what was sealed, but the passphrase is bad. This is good news.
 
-After 3 unsuccessful attempts releasing TPM Disk Unlock Key, Heads will propose you to decrypt with your Disk Recovery Key passphrase, directly from the OS, bypassing Heads protection. 
+After 3 unsuccessful attempts releasing TPM Disk Unlock Key, Heads will propose you to decrypt with your Disk Recovery Key passphrase, directly from the OS, bypassing Heads protection. Still good news.
 
 If Disk Unlock Key passphrase throws a different error, it would be a good idea to meditate on your threat model and what happened to your computer since your last normal default boot.
+
+The Disk Unlock Key is sealed in TPM NV memory with PCRs-2-4-5-6-7, which includes external content from the firmware, like your LUKS header measurements.
 

--- a/Community.md
+++ b/Community.md
@@ -9,7 +9,8 @@ Slack Open Source Firmware
 ===
 
 * [Register to Slack's Open Source Firmware](https://slack.osfw.dev/)
-* [Head's Slack Channel](https://osfw.slack.com/archives/C92MNSRC1)
+* [Heads Slack Channel](https://osfw.slack.com/archives/C92MNSRC1)
+* [Matrix bridge to Heads Slack Channel ](https://matrix.to/#/#OSFW-Heads:matrix.org)
 
 Found a bug
 ===

--- a/Development/Contributing-to-Heads-Wiki.md
+++ b/Development/Contributing-to-Heads-Wiki.md
@@ -104,6 +104,9 @@ replacing `YOUR_USERNAME_HERE` with your GitHub username.
 
 Please note that the URL is similar but NOT the same as the wiki pages feature in your fork in github.
 
+### Verifying broken links
+Please verify `https://YOUR_USERNAME_HERE.github.io/heads-wiki/` with `https://validator.w3.org/checklink` prior of pushing your changes. 
+
 ### Pushing Changes Upstream
 
 Create a pull request in the osresearch/heads-wiki project that points to your changes to request review and contribute back to the parent project.

--- a/Installing-and-Configuring/Building-Heads/general.md
+++ b/Installing-and-Configuring/Building-Heads/general.md
@@ -107,61 +107,6 @@ Please continue to the corresponding flashing guide for your device.
 
 More options and detail about Heads modules under [Makefile](https://github.com/osresearch/heads/blob/master/Makefile)
 
-Downloading Heads
-===
-Alternatively, you can download ROMs directly from CircleCI for recent commits.
-A lot of efforts have been put into CircleCI so that most of the most used 
-community platforms have their ROMs generated and downloadable as artifacts
-from CircleCI. Note that CircleCI keeps artifacts for 30 days after build time.
-Considering Heads is a rolling release as of now, it is advised to wait a day
-or two prior of flashing a ROM downloaded from CircleCI if you do not own a 
-external programmer, to make sure everything is kosher. Maybe wait even longer
-when its a question of coreboot upgrade or kernel upgrade, just to be sure.
-
-Heads is hosted on github, and most of the Pull Requests (PR) are merged 
-upstream after review. Most of the changes happening in the codebase are
-policy related, and those policy changes can normally be tested easily 
-on a specific platform it it needed and have no effect on platforms that
-do not use it. The general advise here is to review the latest PR linked
-to the commit that was merged and make sure that some [other owners of the
-same platform you use](https://github.com/osresearch/heads/issues/692) has tested the changes if you are in doubt.
-
-How to download
----
-
-- Go to Heads GitHub repository and click on latest commit's green check
-![2022-05-10-161753](https://user-images.githubusercontent.com/827570/167725941-e6fcad76-2549-4ffe-88ac-33f92545397b.png)
-- Select your desired platform (hopefully, [choosing maximized builds over legacy counterparts](https://osresearch.net/Prerequisites#legacy-vs-maximized-boards) and choosing hotp variants if you already own a [compatible USB Security dongle](https://osresearch.net/Prerequisites#usb-security-dongles-aka-security-token-aka-smartcard)). Here, we choose x230-hotp-maximized as an example.
-![2022-05-10-161811](https://user-images.githubusercontent.com/827570/167726540-d8ce8d1f-f25a-4ff2-b4e6-2e88e5051cd8.png)
-- This brings us to CircleCI web interface. First, we scroll and click on the `Make Board` step so we can see the hash of the ROM we are about to download
-![2022-05-10-161907](https://user-images.githubusercontent.com/827570/167726969-5ff7fdfc-81df-4a2e-b552-0ec2ec4aa659.png)
-- This opens the build log and shows the last output of the board being built. Highlight/copy the hash for future comparison.
-![2022-05-10-162016](https://user-images.githubusercontent.com/827570/167727116-a7559cd4-6db2-4fd2-a4a4-a254a4add0eb.png)
-- Scroll back up and select the `Artifacts` tab.
-![2022-05-10-162037](https://user-images.githubusercontent.com/827570/167727221-b158912b-c798-4002-8d9a-93a6fbf14f85.png)
-- This opens the artifacts that were saved for that commit id. We are interested in the ROM we are interested to download, which is the full ROM in this upgrade example, as opposed to `bottom` and `top` ROM images which are aimed to be flashed externally.
-![2022-05-10-162056](https://user-images.githubusercontent.com/827570/167727408-1e1c23bb-5afb-4ead-806f-7c65d58ab906.png)
-- Save the link to your already prepared and mounted USB drive locally
-![2022-05-10-162112](https://user-images.githubusercontent.com/827570/167727582-2c15cdc1-c1ec-4289-8548-7b9afc79a40b.png)
-- Validate the checksum against saved checksum
-![2022-05-10-162349](https://user-images.githubusercontent.com/827570/167727751-44d6ba06-29f5-48ea-b955-48db4edbe251.png)
-- If you saved it locally, pass it over to sys-usb once you verified checksum for compartmentalization
-![2022-05-10-162649](https://user-images.githubusercontent.com/827570/167727877-32606e55-4601-4ff8-ad3b-916cb8bde922.png)
-- Mount your USB drive and move the ROM to it
-![2022-05-10-162825](https://user-images.githubusercontent.com/827570/167727965-7a7e9e7f-73fa-4d4c-a0ac-83b30d38584d.png)
-![2022-05-10-162915](https://user-images.githubusercontent.com/827570/167728027-a5918a1e-4c8d-478c-8365-a0b512da0944.png)
-- Unmount your USB drive by pressing the eject button.
-- Boot your Heads laptop, go into recovery shell to make sure you know what you are doing
-  - If aiming to go to maximized firmware, make sure you have unlocked Intel Flash Descriptor (IFD) and ME regions on initial flash
-    - This is compatible![CanBeFlashedToMaximizedRom](https://user-images.githubusercontent.com/827570/167728631-85a5ca9e-48f6-4d4f-8544-532fa75bf5d3.jpeg)
-      - If you have no warning/error (see above), you can proceed: ![InternalUpgradeToMacimizedROM](https://user-images.githubusercontent.com/827570/167729694-6ff8da60-986a-4ec3-9b2d-4fa94e42d3fa.jpeg)
-    - This is not compatible ![CantBeInternallyUpgradeToMaximizedROM](https://user-images.githubusercontent.com/827570/167728658-731362da-a676-4610-becb-ff94f2ff48b1.jpeg)
-      - You either have to download a non-maximized ROM version, or flash externally the top and bootom ROMs of the maximized board.  
-
-
-
-
-
 
 
 

--- a/Installing-and-Configuring/Downloading.md
+++ b/Installing-and-Configuring/Downloading.md
@@ -2,7 +2,7 @@
 layout: default
 title: Step 1 - Downloading Heads
 nav_order: 2
-permalink: /Downloading/
+permalink: /Downloading
 parent: Installing and configuring
 ---
 
@@ -17,53 +17,67 @@ parent: Installing and configuring
 </details>
 <!-- markdownlint-enable MD033 -->
 
-What to download
+What to download/How to upgrade
 ===
-- Boot your Heads laptop, go into [Recovery Shell](/Recovery) to make sure if you should download [Legacy or Maximized](/Prerequisites#legacy-vs-maximized-boards) board ROMs:
+
+What board configuration should I choose?
+---
+Please refer to the [devices compatibility matrix]({{ site.baseurl }}/Prerequisites#supported-devices).
+
+Migrating from on board configuration to another
+---
+If Heads is already installed on your board and you want to migrate to its Maximized version:
+- Under Heads: go into [Recovery Shell]({{ site.baseurl }}/RecoveryShell) to make sure if you should download [Legacy or Maximized]({{ site.baseurl }}/Prerequisites#legacy-vs-maximized-boards) board ROMs:
   - If aiming to go to Maximized firmware, make sure you have unlocked Intel Flash Descriptor (IFD) and ME regions on initial flash
     - *This is compatible* ![CanBeFlashedToMaximizedRom](https://user-images.githubusercontent.com/827570/167728631-85a5ca9e-48f6-4d4f-8544-532fa75bf5d3.jpeg)
       - If you have no warning/error (see above), you can proceed with a manual flashrom command to migrate once and for all to Maximized board: ![InternalUpgradeToMacimizedROM](https://user-images.githubusercontent.com/827570/167729694-6ff8da60-986a-4ec3-9b2d-4fa94e42d3fa.jpeg)
     - *!!!This is not compatible!!!* ![CantBeInternallyUpgradeToMaximizedROM](https://user-images.githubusercontent.com/827570/167728658-731362da-a676-4610-becb-ff94f2ff48b1.jpeg)
       - You either have to download a non-maximized ROM version, or have to flash externally the (xx30 boards: top and bottom) ROM(s) for your platform's maximized board configuration. This needs to be done once, after which you can upgrade from the GUI.
 
+
+
 Downloading Heads from CircleCI
 ===
-Alternatively, you can download ROMs directly from CircleCI for recent commits.
+Alternatively to building your own ROM, you can download ROMs directly from CircleCI for 
+the most recent commits (build artifacts are kept for 30 days automatically). If no
+artifacts are available for download, please [poke us]({{ site.baseurl }}/community/) so we manually relaunch a build.
 
-A lot of efforts have been put into CircleCI so that most of the most used 
-community platforms have their ROMs generated and downloadable as artifacts
-from CircleCI. 
+A lot of efforts have been put into CircleCI so that most of the community platforms 
+have their ROMs built and downloadable as artifacts from CircleCI. 
 
 Note that CircleCI keeps artifacts for 30 days after build time.
 
+No hardware programmer? BE CAUTIOUS!
+---
 Considering Heads is a rolling release as of now, it is advised to wait a day
 or two prior of flashing a ROM downloaded from CircleCI if you do not own a 
-external programmer, to make sure everything absolutely no regression has been 
-reported. Maybe wait even longer when last merge was linked to coreboot upgrade 
-or kernel upgrade, just to be sure. Watch the [most recently reported issues](https://github.com/osresearch/heads/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
-
+[external programmer]({{ site.baseurl }}/Prerequisites). 
+Maybe wait even longer when last merge was linked to a coreboot upgrade 
+or kernel upgrade, just to be sure no regression happened.
+Watch the [most recently reported issues](https://github.com/osresearch/heads/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc). 
 Heads project is hosted on GitHub where most of the Pull Requests (PR) are 
 [merged and closed after review(purple)](https://github.com/osresearch/heads/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc). 
+The general advise here is to review the latest PR linked to last commit 
+that was merged and make sure that some [other owners of the same platform you use](https://github.com/osresearch/heads/issues/692) 
+have tested the changes if you are in doubt.
 
 Most of the changes happening in the codebase are policy related (scripts).
-Those changes can normally be tested on any other platform and are normally
-tested at least on two different platforms to make sure no regression happen.
-The general advise here is to review the latest PR linked
-to last commit that was merged and make sure that some [other owners of the
-same platform you use](https://github.com/osresearch/heads/issues/692) have 
-tested the changes if you are in doubt.
 
-If you do not own an [external programmer](/Installing-and-Configuring/Prerequisites), please
-be less adventurous and make sure that no coreboot/linux version was recently
-pushed without other board owners having tested and reported positive results
-for your board.
+Those changes are normally tested on at least 2 different platforms to validate 
+no regression happened prior of merging. 
+
+Kernel and coreboot version bumps require a lot more testing from the community
+board owners prior of merging the changes in the project. When those cause 
+regressions, an untested platform might simply brick. This is why coreboot/linux
+version bumps are not following upstream projects versions tightly: it requires
+a lot of collaboration and time with [board owners](https://github.com/osresearch/heads/issues/692).
 
 How to download
 ---
 
 - Go to Heads GitHub repository and click on latest commit's green check
 ![2022-05-10-161753](https://user-images.githubusercontent.com/827570/167725941-e6fcad76-2549-4ffe-88ac-33f92545397b.png)
-- Select your desired platform (hopefully, [choosing maximized builds over legacy counterparts](https://osresearch.net/Prerequisites#legacy-vs-maximized-boards) and choosing hotp variants if you already own a [compatible USB Security dongle](https://osresearch.net/Prerequisites#usb-security-dongles-aka-security-token-aka-smartcard)). Here, we choose x230-hotp-maximized as an example.
+- Select your desired platform (hopefully, [choosing maximized builds over legacy counterparts]({{ site.baseurl }}/Prerequisites#legacy-vs-maximized-boards) and choosing hotp variants if you already own a [compatible USB Security dongle]({{ site.baseurl }}/Prerequisites#usb-security-dongles-aka-security-token-aka-smartcard)). Here, we choose x230-hotp-maximized as an example.
 ![2022-05-10-161811](https://user-images.githubusercontent.com/827570/167726540-d8ce8d1f-f25a-4ff2-b4e6-2e88e5051cd8.png)
 - This brings us to CircleCI web interface. First, we scroll and click on the `Make Board` step so we can see the hash of the ROM we are about to download
 ![2022-05-10-161907](https://user-images.githubusercontent.com/827570/167726969-5ff7fdfc-81df-4a2e-b552-0ec2ec4aa659.png)
@@ -86,15 +100,4 @@ How to download
 
 Upgrading firmware
 ===
-The documentation related to upgrading is [here](/Updating)
-
-
-
-
-
-
-
-
-
-
-
+The documentation related to upgrading is [here]({{ site.baseurl }}/Updating)

--- a/Installing-and-Configuring/Downloading.md
+++ b/Installing-and-Configuring/Downloading.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: Step 1 - Downloading Heads
+nav_order: 2
+permalink: /Downloading/
+parent: Installing and configuring
+---
+
+<!-- markdownlint-disable MD033 -->
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+<!-- markdownlint-enable MD033 -->
+
+What to download
+===
+- Boot your Heads laptop, go into [Recovery Shell](/Recovery) to make sure if you should download [Legacy or Maximized](/Prerequisites#legacy-vs-maximized-boards) board ROMs:
+  - If aiming to go to Maximized firmware, make sure you have unlocked Intel Flash Descriptor (IFD) and ME regions on initial flash
+    - *This is compatible* ![CanBeFlashedToMaximizedRom](https://user-images.githubusercontent.com/827570/167728631-85a5ca9e-48f6-4d4f-8544-532fa75bf5d3.jpeg)
+      - If you have no warning/error (see above), you can proceed with a manual flashrom command to migrate once and for all to Maximized board: ![InternalUpgradeToMacimizedROM](https://user-images.githubusercontent.com/827570/167729694-6ff8da60-986a-4ec3-9b2d-4fa94e42d3fa.jpeg)
+    - *!!!This is not compatible!!!* ![CantBeInternallyUpgradeToMaximizedROM](https://user-images.githubusercontent.com/827570/167728658-731362da-a676-4610-becb-ff94f2ff48b1.jpeg)
+      - You either have to download a non-maximized ROM version, or have to flash externally the (xx30 boards: top and bottom) ROM(s) for your platform's maximized board configuration. This needs to be done once, after which you can upgrade from the GUI.
+
+Downloading Heads from CircleCI
+===
+Alternatively, you can download ROMs directly from CircleCI for recent commits.
+
+A lot of efforts have been put into CircleCI so that most of the most used 
+community platforms have their ROMs generated and downloadable as artifacts
+from CircleCI. 
+
+Note that CircleCI keeps artifacts for 30 days after build time.
+
+Considering Heads is a rolling release as of now, it is advised to wait a day
+or two prior of flashing a ROM downloaded from CircleCI if you do not own a 
+external programmer, to make sure everything absolutely no regression has been 
+reported. Maybe wait even longer when last merge was linked to coreboot upgrade 
+or kernel upgrade, just to be sure. Watch the [most recently reported issues](https://github.com/osresearch/heads/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
+
+Heads project is hosted on GitHub where most of the Pull Requests (PR) are 
+[merged and closed after review(purple)](https://github.com/osresearch/heads/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc). 
+
+Most of the changes happening in the codebase are policy related (scripts).
+Those changes can normally be tested on any other platform and are normally
+tested at least on two different platforms to make sure no regression happen.
+The general advise here is to review the latest PR linked
+to last commit that was merged and make sure that some [other owners of the
+same platform you use](https://github.com/osresearch/heads/issues/692) have 
+tested the changes if you are in doubt.
+
+If you do not own an [external programmer](/Installing-and-Configuring/Prerequisites), please
+be less adventurous and make sure that no coreboot/linux version was recently
+pushed without other board owners having tested and reported positive results
+for your board.
+
+How to download
+---
+
+- Go to Heads GitHub repository and click on latest commit's green check
+![2022-05-10-161753](https://user-images.githubusercontent.com/827570/167725941-e6fcad76-2549-4ffe-88ac-33f92545397b.png)
+- Select your desired platform (hopefully, [choosing maximized builds over legacy counterparts](https://osresearch.net/Prerequisites#legacy-vs-maximized-boards) and choosing hotp variants if you already own a [compatible USB Security dongle](https://osresearch.net/Prerequisites#usb-security-dongles-aka-security-token-aka-smartcard)). Here, we choose x230-hotp-maximized as an example.
+![2022-05-10-161811](https://user-images.githubusercontent.com/827570/167726540-d8ce8d1f-f25a-4ff2-b4e6-2e88e5051cd8.png)
+- This brings us to CircleCI web interface. First, we scroll and click on the `Make Board` step so we can see the hash of the ROM we are about to download
+![2022-05-10-161907](https://user-images.githubusercontent.com/827570/167726969-5ff7fdfc-81df-4a2e-b552-0ec2ec4aa659.png)
+- This opens the build log and shows the last output of the board being built. Highlight/copy the hash for future comparison.
+![2022-05-10-162016](https://user-images.githubusercontent.com/827570/167727116-a7559cd4-6db2-4fd2-a4a4-a254a4add0eb.png)
+- Scroll back up and select the `Artifacts` tab.
+![2022-05-10-162037](https://user-images.githubusercontent.com/827570/167727221-b158912b-c798-4002-8d9a-93a6fbf14f85.png)
+- This opens the artifacts that were saved for that commit id. We are interested in the ROM we are interested to download, which is the full ROM in this upgrade example, as opposed to `bottom` and `top` ROM images which are aimed to be flashed externally.
+![2022-05-10-162056](https://user-images.githubusercontent.com/827570/167727408-1e1c23bb-5afb-4ead-806f-7c65d58ab906.png)
+- Save the link to your already prepared and mounted USB drive locally
+![2022-05-10-162112](https://user-images.githubusercontent.com/827570/167727582-2c15cdc1-c1ec-4289-8548-7b9afc79a40b.png)
+- Validate the checksum against saved checksum
+![2022-05-10-162349](https://user-images.githubusercontent.com/827570/167727751-44d6ba06-29f5-48ea-b955-48db4edbe251.png)
+- If you saved it locally, pass it over to sys-usb once you verified checksum for compartmentalization
+![2022-05-10-162649](https://user-images.githubusercontent.com/827570/167727877-32606e55-4601-4ff8-ad3b-916cb8bde922.png)
+- Mount your USB drive and move the ROM to it
+![2022-05-10-162825](https://user-images.githubusercontent.com/827570/167727965-7a7e9e7f-73fa-4d4c-a0ac-83b30d38584d.png)
+![2022-05-10-162915](https://user-images.githubusercontent.com/827570/167728027-a5918a1e-4c8d-478c-8365-a0b512da0944.png)
+- Unmount your USB drive by pressing the eject button.
+
+Upgrading firmware
+===
+The documentation related to upgrading is [here](/Updating)
+
+
+
+
+
+
+
+
+
+
+

--- a/Installing-and-Configuring/Prerequisites.md
+++ b/Installing-and-Configuring/Prerequisites.md
@@ -6,6 +6,17 @@ nav_order: 1
 parent: Installing and configuring
 ---
 
+<!-- markdownlint-disable MD033 -->
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+<!-- markdownlint-enable MD033 -->
+
 Prerequisites for Heads
 ===
 
@@ -68,8 +79,24 @@ Please see the current [heads source](https://github.com/osresearch/heads/tree/m
 |Purism Librem Mini v2|`librem_mini_v2`|coreboot||||
 |Purism Librem 14|`librem_14`|coreboot||||
 
-Legacy vs Maximized boards
+USB Security Dongles (aka security token aka smartcard)
 ---
+
+*NOTE* - Heads does **NOT** support FIDO2 or U2F authentication.  Be careful when
+ purchasing to buy a compatible key.
+
+ *NOTE* - HOTP is currently only supported with Librem devices and the ThinkPad
+  x230 rom with HOTP support
+
+|Manufacture|Model line|TOTP|HOTP|
+|--|--|:--:|:--:|
+|Yubico|[YubiKey 5 Series](https://www.yubico.com/products/yubikey-5-overview/)|X||
+|Nitrokey|[Nitrokey Pro 2](https://www.nitrokey.com/#comparison)|X|X|
+|Nitrokey|[Nitrokey Storage 2](https://www.nitrokey.com/#comparison)|X|X|
+|Purism|[Librem Key](https://puri.sm/products/librem-key/)|X|X|
+
+Legacy vs Maximized boards
+===
 Some history first on the historical x230-flash and x230 boards that initially created the Heads project.
 
 Heads was initially developped on the x230 board. 
@@ -113,11 +140,13 @@ It is possible to upgrade from Legacy to Maximized boards under certain conditio
 
 If coming from Skulls, *if and only optional unlocking step has been followed*, you can upgrade internally through a manual flashrom call, just like if you were coming from Heads Legacy boards while having followed the me_cleaning page instructions prior of initial flash.
 
-If coming from Skulls or Heads Legacy board configurations while having unlocked IFD initially, you can flash from the recovery shell manually. 
+If coming from Skulls or Heads Legacy board configurations while having unlocked IFD initially, you can flash from the recovery shell manually.
+[**IF UNSURE, PLEASE VERIFY FIRST**](/Prerequisites#legacy-vs-maximized-boards) 
+
 Having a full xxxx-hotp-maximized or xxxx-maximized board config produced ROM available on a USB stick, alongside with your USB Security dongle's matching exported public key, do the following:
 ```
 mount-usb
-flashrom --force --noverify-all -p internal -w /media/PathToMaximizedRom.rom
+flashrom -p internal -w /media/PathToMaximizedRom.rom
 ```
 On next reboot, Heads will guide you into factory resetting your USB Security dongle or import your previously generated public key matching your USB Security dongle's private key. 
 
@@ -126,7 +155,7 @@ It will then regenerate a TOTP/HOTP secret and sign /boot content. You will then
 In the case nothing is found installed on your disk, Heads will propose you to boot from USB to install a new Operating System, prior of being able to do the above steps prior of booting into your system.
 
 Emulated devices
----
+===
 
 For further information, see [Emulating Heads](/Emulating-Heads/)
 
@@ -135,19 +164,3 @@ For further information, see [Emulating Heads](/Emulating-Heads/)
 |QEMU development image|`qemu-coreboot-fbwhiptail`|coreboot|
 |QEMU development image|`qemu-coreboot`|coreboot|
 |QEMU development image|`qemu-linuxboot`|linuxboot|
-
-USB Security Dongles (aka security token aka smartcard)
----
-
-*NOTE* - Heads does **NOT** support FIDO2 or U2F authentication.  Be careful when
- purchasing to buy a compatible key.
-
- *NOTE* - HOTP is currently only supported with Librem devices and the ThinkPad
-  x230 rom with HOTP support
-
-|Manufacture|Model line|TOTP|HOTP|
-|--|--|:--:|:--:|
-|Yubico|[YubiKey 5 Series](https://www.yubico.com/products/yubikey-5-overview/)|X||
-|Nitrokey|[Nitrokey Pro 2](https://www.nitrokey.com/#comparison)|X|X|
-|Nitrokey|[Nitrokey Storage 2](https://www.nitrokey.com/#comparison)|X|X|
-|Purism|[Librem Key](https://puri.sm/products/librem-key/)|X|X|

--- a/Installing-and-Configuring/Upgrading.md
+++ b/Installing-and-Configuring/Upgrading.md
@@ -6,54 +6,122 @@ nav_order: 99
 parent: Installing and configuring
 ---
 
+<!-- markdownlint-disable MD033 -->
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+<!-- markdownlint-enable MD033 -->
+
+
 ![Flashing Heads on an x230 at HOPE]({{ site.baseurl }}/images/Flashing_Heads_on_an_x230_at_HOPE.jpg)
+
+
+Acessing Heads Recovery shell
+===
+
+![Recovery shell](/images/Recovery_shell.jpg)
+
+If the flash protection bits are set correctly it is not possible to
+ rewrite the firmware from the normal OS.  You'll need to reboot
+ to the Heads [recovery shell](/RecoveryShell/).
+
+Repeatedly press 'r' on boot or choose 'Exit to Recovery Shell' from Heads menus.
+
+
+Reflashing the same firmware
+===
+If you reflash the same firmware image by selecting the retain settings option from Heads GUI, your 
+ TOTP/HOTP/TPM Disk Unlock Key and passphrase will stay valid since measurements will repopulate PCRs
+ exactly the same way, resulting in the same sealed secrets.
+
+So if you are in doubt of the current firmware state, you can consequently reflash the firmware image 
+ to validate it's current integrity. It is a good idea to keep last flashed firmware image on a USB
+ drive.
+
+Bonus, Maximized ROMs reflash the whole SPI flash; not just the BIOS region like Legacy ROMs do.
+
 
 Upgrading Heads
 ===
 
-The first time you install Heads, you'll need a
-[hardware flash programmer](https://trmm.net/SPI_flash) to be able to
-replace the existing vendor firmware.  Subsequent upgrades can be
-performed via software, although you'll probably want a hardware programmer
-since we don't have a fail-safe recovery mechanism in the event of
-a bad flash or buggy firmware.
+The first time you install Heads, you'll need [some SPI programmer](/Prerequisites#required-equipment) 
+ to be able to replace the existing vendor firmware.  
 
-Additionally, *reflashing the firmware will change the TPM PCRs*.
-This will require generating a new TPM TOTP token and a new drive
-encryption key.  Be sure you have your TPM owner's password and your
-disk encryption recovery key or passphrase available since, by design,
-the disk key is not accessible to the recovery shell.
+Subsequent upgrades can be performed internally through Heads menus although you'll probably 
+ want a hardware programmer since we don't have a fail-safe recovery mechanism in the event of
+ a bad flash or buggy firmware.
 
-If you flash the same firmware and you keep settings, your TOTP will be valid, HOTP also, and Disk Unlock Key passphrase will still boot your system. In doubt, you can consequently reflash your firmware.
+Additionally, *upgrading the firmware will change the [TPM PCRs](/Keys/#tpm-pcrs)*.
+ This will require resealing TOTP/HOTP and to setup a new TPM Disk Unlock Key and passphrase
+ by setuping a new boot default.  
 
-The Disk Recovery Key is the key used at OS installation for the encrypted root partition (passphrase placed in LUKS keyslot 0).
+Be sure you have your TPM owner's password and your Disk Recovery Key passphrase available 
+ since, by design, the TPM Disk Unlock Key will become invalid. Also note that TPM PCRs are 
+ extended by going to the recovery shell anyway, which does not permit to have access to
+ sealed secrets from there.
 
 
-Recovery shell
----
+Verify upgradeability paths of the firmware
+====
 
-![Recovery shell]({{ site.baseurl }}/images/Recovery_shell.jpg)
+It is a good time to review if the Intel Firmware Descriptor (IFD) and
+ Intel Management Engine (ME) were unlocked or not. 
 
-If the flash protection bits are set correctly it is not possible to
-rewrite the firmware from the normal OS.  You'll need to reboot
-to the Heads [recovery shell](/RecoveryShell/).  Repeatedly press 'r' on boot or choose 'Recovery Shell' in the heads GUI.
+```shell
+flashrom -p internal
+```
+
+
+Unlocked IFD and ME
+----
+This is the expected output if the initial external flashing of the firmware unlocked IFD and ME regions:
+![CanBeFlashedToMaximizedRom](https://user-images.githubusercontent.com/827570/167728631-85a5ca9e-48f6-4d4f-8544-532fa75bf5d3.jpeg)
+- This means you can internally migrate from Legacy boards (xxxx-hotp/xxxx boards ROM) to their Maximized boards counterpart (xxx-hotp-maximized/xxxx-maximized boards ROM).
+  - If you are presently on a Legacy board (If Heads boot screen is not showing Maximized):
+    - You will have to manually call flashrom from the Recovery Console:
+    - ![InternalUpgradeToMaximizedROM](https://user-images.githubusercontent.com/827570/167729694-6ff8da60-986a-4ec3-9b2d-4fa94e42d3fa.jpeg)
+- If you are already running a Maximized board ROM, you can safely upgrade through Heads GUI keeping your current settings. 
+
+
+Locked IFD and ME
+----
+Otherwise, initial external flashing of the firmware didn't unlock the IFD/ME regions:
+![CantBeInternallyUpgradeToMaximizedROM](https://user-images.githubusercontent.com/827570/167728658-731362da-a676-4610-becb-ff94f2ff48b1.jpeg)
+- This means you either have to:
+  - Externally reflash Maximized board ROM 
+    - xx30: xx30-*maximized-top.rom(4Mb) and xx30-*maximized-bottom.rom(8Mb) ROMs 
+    - xx20: xx20-*-maximized.rom (8Mb ROM)
+  - Stay with Legacy board ROMs. This means you can safely update through Heads GUI, keeping your current settings.
+
 
 Internal Flashing
+===
+
+On the laptop used to build/download Heads 
 ---
+For safety, list the drives available without plugging your USB drive:
+```shell
+sudo fdisk -l
+```
 
-Reconnect power to the laptop and you should be able to boot into the Heads
- recovery shell.
 
-Plug your USB flash drive into the laptop that you used to build Heads. If your
- USB drive is already formatted as ext4 or you are confident you can format it
- then just move the coreboot.rom file to the usb drive. Otherwise, find your usb
- drive using fdisk:
+Plug your USB flash drive and redo last command to witness appearance of a new drive:
 
 ```shell
 sudo fdisk -l
 ```
 
-Format your usb drive as ext4 (My usb drive is /dev/sdb):
+Note that Heads currently supports ext3/ext4/fat32 filesystems, where fat32 limits 
+ file size to a maximum of 4Gb. So if you intend to use that USB drive to host bigger
+ files, you should probably backup current content and format to ext3/ext4.
+ Otherwise, fat32 is fine now to put only firmware image.
+
+If you want to reformat your usb drive as ext4 (USB drive is /dev/sdb here):
 
 ```shell
 sudo mkfs.ext4 /dev/sdb1
@@ -67,97 +135,44 @@ mkdir ~/usb
 sudo mount /dev/sdb1 ~/usb/
 ```
 
-Move the full Heads rom file to the usb drive:
+Move the full Heads rom file to the usb drive and unmount the drive:
 
 ```shell
-sudo cp ~/heads/build/x230/coreboot.rom ~/usb/
+sudo cp ~/heads/build/x230/heads.rom ~/usb/
+sudo umount /dev/sdb1
 ```
 
-Insert the usb drive into the Thinkpad x230 and mount it:
 
-```shell
-mount-usb
-```
-
-You should now see the file coreboot.rom in /media:
-
-```shell
-ls /media/
-```
-
-Internally flash coreboot.rom (This command will write to both SPI flash chips
-  as if they are one 12Mb chip):
-
-```shell
-flash.sh -c /media/coreboot.rom
-```
-
-Wait for the flashing to finish and you should be able to reboot into Heads!
-
-Mounting the USB media
+Flashing new firmware under Heads
 ---
+As discussed above: 
 
-![insmod]({{ site.baseurl }}/images/insmod.jpg)
+- If you are not migrating from Legacy boards to Maximized board configurations, 
+ you can safely upgrade from Heads GUI through `Options->Flash/Update BIOS`
+ and choose the retain settings option. This will copy your GPG keyring and user configuration
+ into the new ROM prior of flashing it the whole combined 12Mb SPI flash with the ROM.
 
-The Heads boot process does not have USB or network drivers by default
-and neither does the recovery shell (although this might change).
-You need to load the Linux kernel modules, which will change the
-default module PCR 5:
+- If you are migrating from Legacy to Maximized ROM, you need to manually call flashrom
+ from the Recovery Shell, having a copy of your public key on a USB drive to inject it back
+ on next Heads boot.
 
-```shell
-insmod /lib/modules/ehci-hcd.ko
-insmod /lib/modules/ehci-pci.ko
-```
 
-When you insert the drive you'll see a console message about the partitions
-on the new device.  Typically it will be the first partition, `/dev/sdb1`,
-or sometimes just `/dev/sdb` if there is no partition table.  Make a
-directory and mount the device read only:
+Re-Owning the states
+===
+Reboot and verify that the new firmware is running. Don't be scared if you have to power off twice
+ The trained memory cache in firmware might have been wiped and reconstructed. Hold the power
+ button for 10 seconds and power back on.
 
-```shell
-mkdir /media
-mount -o ro /dev/sdb1 /media
-```
+- If you migrated from Legacy to Maximized builds (no migration of settings), you will
+ be prompted on next reboot by the same prompts following an initial flash. That is:
+  - To inject your public key or do OEM Factory Reset/Re-Ownership
+    - The Factory Reset/Re-Ownership option will guide you into re-owning all security components
+     including resetting USB Security dongle, injecting public key in ROM and signing /boot.
+  - Then on next reboot, you will be prompted to generate new TOTP/HOTP token. Normal, since none
+   of the previous measurements are valid anymore (GPG Admin PIN and TPM Ownership passphrase required)
+  - Sign /boot content (GPG User PIN required)
+  - Select a new boot default through Boot Options (GPG User PIN required to sign the new default)
+    - Optionally set a TPM Disk Unlock Key (Disk Recovery Key passphrase and GPG User PIN required)
 
-Flashing the ROM
----
-
-![Mount and flash]({{ site.baseurl }}/images/Mount_and_flash.jpg)
-
-There is a helper script `/bin/flashrom-x230.sh` that uses the x230
-flash ROM layout and the Heads modified version of `flashrom` to
-write to the chip.  One of the modifications is to avoid touching or
-reading the ME section, so it is not necessary to have used the
-[ME cleaner](/Clean-the-ME-firmware/) or unlocked the flash descriptor.
-
-```shell
-flashrom-x230.sh /media/x230.full.rom
-```
-
-![Flashrom]({{ site.baseurl }}/images/Flashrom.jpg)
-
-If all goes well it will write for about a minute and then report
-success.  Due to hacks in `flashrom`, it does not read back what it
-wrote to verify, so hopefully it worked.
-
-Reboot and verify that the new firmware is running.  You'll be dropped
-into the recovery shell immediately since the TPM TOTP secret will not
-be unlocked.  Since the first boot after flashing will also adjust
-the MRC cache, it is necessary to do a second reboot to ensure that
-the TPM values are at their persistent state
-([issue #150](https://github.com/osresearch/heads/issues/150) aims to fix this).
-
-Regenerating the TOTP token
----
-
-![TPM TOTP QR]({{ site.baseurl }}/images/TPM_TOTP_QR.jpg)
-
-After the second post-flash reboot, generate a new token and store the
-QR code in your phone by running:
-
-```shell
-sealtotp.sh
-```
-
-This needs the TPM owner password to be able to define the NVRAM space.
-(todo: [issue #151](https://github.com/osresearch/heads/issues/151)).
+- If you upgraded your firmware by choosing the retain settings options for a same board configuration 
+  - The same steps above will be required, outside of the public key injection/Re-Ownership.

--- a/Installing-and-Configuring/index.md
+++ b/Installing-and-Configuring/index.md
@@ -18,6 +18,10 @@ Prerequisites
 Heads is supported on a limited set of hardware (laptop and security dongle).  First, check the [Prerequisites](/Prerequisites) page for details.
 
 
+Downloading
+----
+You can [download ROMs](/Downloading) directly from CircleCI for most of the boards configurations supported.
+
 Building
 ----
 

--- a/index.md
+++ b/index.md
@@ -55,7 +55,7 @@ Further reading
 Learn more about Heads
 ---
 
-* [Heads threat model](/Heads-threat-model/) - goes into more
+* [Heads threat model]({{ site.baseurl }}/Heads-threat-model/) - goes into more
  detail about what classes of threats Heads attempts to counter.
-* [Frequently Asked Questions](/FAQ/)
-* [Requirements for Heads](/Install-and-Configure)
+* [Frequently Asked Questions]({{ site.baseurl }}/FAQ/)
+* [Requirements for Heads]({{ site.baseurl }}/Install-and-Configure)


### PR DESCRIPTION
WiP. 

**_As of now changes are visible from these pages:_** 
- https://tlaurion.github.io/heads-wiki/ (added another Step 1 - Downloading)
- https://tlaurion.github.io/heads-wiki/Downloading
- https://tlaurion.github.io/heads-wiki/Updating
- https://tlaurion.github.io/heads-wiki/Prerequisites
- https://tlaurion.github.io/heads-wiki/community/
- https://tlaurion.github.io/heads-wiki/Keys/#tpm-pcrs (to end of page)

**Present goals of this PR**:
- [x] Have a cleaner view of how to upgrade firmware addressing concerns of fearful users (including Legacy to Maximized builds)
- [x] Have a clearer view of how to download firmware from CI
- [x] Cross-link download/build instructions. Move things away
- [x] Have TOC where needed on top of modified pages
- [x] Remove duplicates from Flashing instructions, Generic build instructions and cross-link where needed instead.
- [ ] Move snippets/simplify docs that are at https://zerolink.ml/1DMb3CV66qZPwJqkgm4z12nu8BrAwDoD4g/?Post:57 following feedback from community