### PR TITLE
x230: Seperate building and install guides between Legacy and Maximized

### DIFF
--- a/Installing-and-Configuring/Building-Heads/x230-maximized.md
+++ b/Installing-and-Configuring/Building-Heads/x230-maximized.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Lenovo X230 Maximized
+permalink: /x230-maximized-building/
+nav_order: 1
+parent: Step 1 - Building Heads
+grand_parent: Installing and configuring
+---
+
+Lenovo X230 Maximized
+====
+
+Please determine the [version]({{ site.baseurl }}/Prerequisites#supported-devices) you want to build (HOTP or not).
+
+For the Thinkpad x230 there are multiple maximized boards under `./boards`, 
+ x230-maximized, x230-hotp-maximized and x230-hotp-maximized_usb-kb.
+
+ All those roms are externally flashable through their top and bottom rom images.
+
+As opposed to Legacy boards produced ROM images, Maximized boards produced ROMs 
+ are totally valid ROMs, including a valid Intel Flash Descriptor (IFD), Ethernet
+ Intel Gigabit configuration flash space fiaxating MAC to DE:AD:C0:FF:EE,
+ a valid neutered Intel ME containing only BUP+ROMP modules which liberated
+ space is given back to the BIOS (coreboot+payload) region. 
+
+x230 maximized boards need blobs to be downloaded and extracted from Lenovo prior 
+ of building the board configuration.
+
+Please refer to the [xx30 blobs documentation](https://github.com/osresearch/heads/blob/master/blobs/xx30/README),
+debian-11 [dependencies tested working per CircleCI](https://github.com/osresearch/heads/blob/7327f3524eadfa9fe77d0477d63d8e42c692c83a/.circleci/config.yml#L16)
+and [how CircleCI call the blobs download script](https://github.com/osresearch/heads/blob/7327f3524eadfa9fe77d0477d63d8e42c692c83a/.circleci/config.yml#L96) to produce ROMs.
+
+You can also [download the ROMs directly from CircleCI]({{ site.baseurl }}/Downloading)
+
+```Makefile
+make BOARD=x230-maximized bootstrap
+make BOARD=x230-maximized
+```
+
+or
+
+```Makefile
+make BOARD=x230-hotp-maximized bootstrap
+make BOARD=x230-hotp-maximized
+```
+
+If running a supported OS (Debian-11/Ubuntu 20.04), have installed proper dependencies, 
+ ran the xx30 blobs download script prior of calling the above make commands for your chosen 
+ board flavor, 3 roms should have been created: 
+- A fully valid 12Mb rom to be flashed internally, also splitted into:
+- A top(4Mb) ROM, to be flashed externally on the top SPI flash chip.
+- A bottom(8Mb) ROM, to be flashed externally on the bottom SPI flash chip
+
+Please continue with the [flashing guide]({{ site.baseurl }}/x230-maximized-flashing/)
+
+More options and detail about Heads modules under [Makefile]({{ site.baseurl }}/Makefile/)

--- a/Installing-and-Configuring/Building-Heads/x230.md
+++ b/Installing-and-Configuring/Building-Heads/x230.md
@@ -1,20 +1,39 @@
 ---
 layout: default
-title: Lenovo X230
+title: Lenovo X230 Legacy
 permalink: /x230-building/
 nav_order: 1
 parent: Step 1 - Building Heads
 grand_parent: Installing and configuring
 ---
 
-Lenovo X230
+Lenovo X230 (Legacy)
 ====
 
-For the Thinkpad x230 there are two boards in `./boards`, x230-flash and x230.
- x230-flash is externally flashable and contains a smaller package that will
- let us boot to the Heads recovery shell. x230 is only internally flashable and
- contains all of Heads. Since we will end up using both x230-flash and x230, it
- makes the most sense to build both now.
+For the Thinkpad x230 Legacy there are two boards "flavors "in `./boards`
+ - x230-flash
+ - x230, x230-hotp-verification
+
+x230-flash is externally flashable into the top SPI flash chip and contains 
+ a smaller package footprint, basically flashrom and dependencies, that will 
+ let us boot to the Heads recovery shell. x230 is only internally flashable 
+ and contains Heads, with a reduced feature set as compared to the maximized
+ flavor.
+
+Since you are planning to externally flash, you should probably go with the
+ maximized flavor now. Maximized boards produce externally flashable top 
+ and bottom rom images, a neutered ME image and a corresponding Intel Flash 
+ Descriptor (IFD), giving Heads its maximized BIOS size footprint of 11.5Mb
+ available space, as compared to 7Mb in Legacy board flavors.
+
+x230-flash can also be flashed internally through 1vyrain, where 1vyrain cannot
+ unlock neither ME or IFD flash regions. By using 1vyrain, you choose to lock
+ yourself to Legacy boards flavor. 1vyrain will not neuter ME. You should
+ consider flashing externally Maximized Heads version instead.
+
+Since we will end up using both x230-flash and our chosen x230 flavor, it makes 
+ the most sense to build both now. Where one last time, you should probably
+ go withthe maximized builds if you have an external reprogrammer.
 
 Initial SPI2 (4MB) flash chip
 -----
@@ -37,7 +56,12 @@ Subsequent flashing (upgrades)
 -----
 
 The following make command will generate a 12MB `coreboot.rom` under the
-build/x230 directory.
+ build/x230 directory, which only contains a valid BIOS region (faked IFD,
+ no ME, no GBE etc) which if flashed over a Maximized board flavor internally
+ will result in a brick, and will require an external reprogrammer to flash
+ the Maximized board roms to fix the problem.
+
+Only Maximized builds are fully externally flashable ROMs.
 
 ```Makefile
 make BOARD=x230

--- a/Installing-and-Configuring/Flashing-Guides/x230-maximized.md
+++ b/Installing-and-Configuring/Flashing-Guides/x230-maximized.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Lenovo X230 Legacy
-permalink: /x230-flashing/
+title: Lenovo X230 Maximized
+permalink: /x230-maximized-flashing/
 nav_order: 1
 parent: Step 2 - Flashing Guides
 grand_parent: Installing and configuring
 ---
 
-Lenovo X230 (Legacy)
+Lenovo X230 (Maximized)
 ===
 
 [X230 Hardware Maintenance Manual](https://web.archive.org/web/20201112030049/https://thinkpads.com/support/hmm/hmm_pdf/x230_x230i_hmm_en_0b48666_01.pdf)  
@@ -58,6 +58,9 @@ Based on [the work done here](https://github.com/osresearch/heads/issues/716),
 |Winbond | W25Q32.V, W25Q32.W | 4M|
 |Winbond | W25Q64.V, W25Q32.W  | 8M|
 
+First [download]({{ site.baseurl }}/Downloading) / [build]({{ site.baseurl }}/x230-maximized-building/) the maximized board roms (top and bottom) for this board and verify their hashes.
+
+
 Try to read the name on the top SPI flash chip. Then, connect the clip and
  ch341a programmer to the top SPI flash chip. Use flashrom to check the chip
   that you are connected to:
@@ -76,10 +79,10 @@ sudo flashrom -r ~/top.bin --programmer ch341a_spi -c YYY && \
 If the files differ then try reconnecting your programmer to the SPI flash chip
  and make sure your flashrom software is up to date.
 
-If they are the same then write `x230-flash.rom` to the SPI flash chip:
+If they are the same then write `x230-maximized-top.rom` to the SPI flash chip:
 
 ```shell
-sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x230-flash/x230-flash.rom
+sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x230-maximized/x230-maximized-top.rom
 ```
 
 Try to read the name on the bottom SPI flash chip. Then, connect the clip and
@@ -97,12 +100,18 @@ sudo flashrom -r ~/bottom.bin --programmer ch341a_spi -c ZZZ && \
     sudo flashrom -v ~/bottom.bin --programmer ch341a_spi -c ZZZ
 ```
 
-The 8M bottom chip contains the ME firmware.  It is strongly suggested that this
- is neutralized.  Please see the section on [Cleaning ME](/Clean-the-ME-firmware/)
+The 8M bottom chip contains the ME firmware.  It is neutralized in maximized version.
+You can flash it specifying the same chip you found under ZZZ:
+```shell
+sudo flashrom -p ch341a_spi -c “ZZZ” -w ~/heads/build/x230-maximized/x230-maximized-bottom.rom
+```
 
-If all goes well, you should see the keyboard LED flash, and within a second the
- Heads recovery splash screen will appear. It currently drops you immediately
- into the shell, to allow you to flash the full 12MB `x230` Heads built rom, with 
- on screen instructions to mount a USB drive and flash that file from it.
- If it doesn't work, well, sorry about that. Please let me know what the symptoms 
- are or what happened during the flashing.
+
+If all goes well, you should see the keyboard LED flash, and within a second Heads will boot
+ in its GUI. 
+
+Two reboots are sometimes needed after flash. Force power off by holding the power button for 
+ 10 seconds. Since the memory training data was wiped by the content of the full flashed ROM, 
+ this is normal.
+
+You should then follow through with [configuring keys]({{ site.baseurl }}/Configuring-Keys/).


### PR DESCRIPTION
Separate Legacy build and flashing instructions from Maximized builds. 

Touches 2 pages:
https://tlaurion.github.io/heads-wiki/x230-building/
https://tlaurion.github.io/heads-wiki/x230-flashing/

Adds two pages:
https://tlaurion.github.io/heads-wiki/x230-maximized-building/
https://tlaurion.github.io/heads-wiki/x230-maximized-flashing/