### PR TITLE
Adapt documentation after PPC64LE architecture addition (build/ ->  build/x86 refs)

### DIFF
--- a/Development/Emulating-Heads.md
+++ b/Development/Emulating-Heads.md
@@ -29,7 +29,7 @@ make BOARD=qemu-coreboot
 Boot it in qemu:
 
 ```Shell
-build/make-4.2/make BOARD=qemu-coreboot run
+make BOARD=qemu-coreboot run
 ```
 
 Use `qemu-coreboot-fbwhiptail` as the board instead for the graphical interface.

--- a/Development/Porting.md
+++ b/Development/Porting.md
@@ -21,11 +21,11 @@ named `./initrd.cpio.xz`.  No command line options are necessary.
 
 * If you want to use `menuconfig` to reconfigure the coreboot file,
 it is a little tricky since we have an external config file.  From the
-top level of the Heads directory you can run:
+top level of the Heads directory you can run, for a x86 board example:
 
 ```shell
 make \
-  -C build/coreboot-4.5 \
+  -C build/x86/coreboot-4.13 \
   DOTCONFIG=../../config/coreboot-newarch.config \
   menuconfig
 ```
@@ -83,7 +83,7 @@ Solution:
 * Run `make BOARD=$BOARD_DIR` (where `$BOARD_DIR` is the board directory
   (`x230`, `x230-flash` and others found under `./boards` directory) to setup
   the coreboot tree, using the new coreboot config file.  This will create the
-  output directory `build/$BOARD_DIR/*.rom`, the rom name should be named
+  output directory `build/x86/$BOARD_DIR/*.rom`, the rom name should be named
   `coreboot.rom`.
 
 * If things don't work, please open an issue on [https://github.com/osresearch/heads/issues](https://github.com/osresearch/heads/issues)

--- a/Development/make-details.md
+++ b/Development/make-details.md
@@ -12,7 +12,7 @@ Makefile
 Helpful targets and options
 ---
 
-Verbose build (otherwise all log output goes into `build/logs/$(submodule).log`):
+Verbose build (otherwise all log output goes into `build/x86/logs/$(submodule).log`):
 
 ```shell
 make V=1
@@ -87,7 +87,7 @@ cryptsetup_hash := af2b04e8475cf40b8d9ffd97a1acfa73aa787c890430afd89804fb544d6ad
 # build path.
 cryptsetup_configure := ./configure \
   CC="$(heads_cc)" \
-  --host i386-elf-linux \
+  --host $(MUSL_ARCH)-elf-linux \
   --prefix "" \
   --disable-gcrypt-pbkdf2 \
   --with-crypto_backend=kernel \
@@ -124,7 +124,7 @@ The main components that every submodule must define are:
  after unpacking and patching (see below) `cryptsetup_configure`
 ** Note that we provide the compiler `CC="$(heads_cc)"` in quotes, since there
  might be spaces in the variable
-  * `--host i386-elf-linux` is used to indicate that this is a cross compile
+  * `--host $(MUSL_ARCH)-elf-linux` is used to indicate that this is a cross compile
   * `--prefix` avoids writing path names into the executable
   * plus some additional submodule specific stuff
 * The target to be called by make in this directory to generate the output

--- a/Installing-and-Configuring/Building-Heads/general.md
+++ b/Installing-and-Configuring/Building-Heads/general.md
@@ -99,8 +99,8 @@ Generally, everything that is needed to flash the SPI flash of a board is a
  make BOARD=XXX CPUS=YY
  ```
 
- The resulting rom file will be either `./build/XXX/XXX.rom` or
-  `./build/XXX/heads-XXX-vYYYY-gZZZZZZZ.rom` (`XXX` should be the name of your board in
+ The resulting rom file for a x86 board will be either `./build/x86/XXX/XXX.rom` or
+  `./build/x86/XXX/heads-XXX-vYYYY-gZZZZZZZ.rom` (`XXX` should be the name of your board in
   `./boards, vYYYY the pinned Heads version and ZZZZZZ the commit id from which your build comes from`).
 
 Please continue to the corresponding flashing guide for your device.

--- a/Installing-and-Configuring/Building-Heads/x230.md
+++ b/Installing-and-Configuring/Building-Heads/x230.md
@@ -50,13 +50,13 @@ The following make command generates a self-contained, externally flashable rom
 make BOARD=x230-flash
 ```
 
-Resulting rom is found under build/x230-flash/x230-flash.rom
+Resulting rom is found under build/x86/x230-flash/x230-flash.rom
 
 Subsequent flashing (upgrades)
 -----
 
 The following make command will generate a 12MB `coreboot.rom` under the
- build/x230 directory, which only contains a valid BIOS region (faked IFD,
+ build/x86/x230 directory, which only contains a valid BIOS region (faked IFD,
  no ME, no GBE etc) which if flashed over a Maximized board flavor internally
  will result in a brick, and will require an external reprogrammer to flash
  the Maximized board roms to fix the problem.

--- a/Installing-and-Configuring/Flashing-Guides/Clean-the-ME-firmware.md
+++ b/Installing-and-Configuring/Flashing-Guides/Clean-the-ME-firmware.md
@@ -76,7 +76,7 @@ If it's not, replace the reprogrammer clip and try again :)
 
 Next, unlock the descriptor and ME regions with ifdtool. We consider here that
  you already build Heads through `make BOARD=x230`:
-`~/heads/build/coreboot-4.8.1/util/ifdtool/ifdtool -u down.rom`
+`~/heads/build/x86/coreboot-4.13/util/ifdtool/ifdtool -u down.rom`
 This produced a new unlocked rom under `down.rom.new`
 
 Next, let's strip all the nasty bits:  

--- a/Installing-and-Configuring/Flashing-Guides/x230-maximized.md
+++ b/Installing-and-Configuring/Flashing-Guides/x230-maximized.md
@@ -82,7 +82,7 @@ If the files differ then try reconnecting your programmer to the SPI flash chip
 If they are the same then write `x230-maximized-top.rom` to the SPI flash chip:
 
 ```shell
-sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x230-maximized/x230-maximized-top.rom
+sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x86/x230-maximized/x230-maximized-top.rom
 ```
 
 Try to read the name on the bottom SPI flash chip. Then, connect the clip and
@@ -103,7 +103,7 @@ sudo flashrom -r ~/bottom.bin --programmer ch341a_spi -c ZZZ && \
 The 8M bottom chip contains the ME firmware.  It is neutralized in maximized version.
 You can flash it specifying the same chip you found under ZZZ:
 ```shell
-sudo flashrom -p ch341a_spi -c “ZZZ” -w ~/heads/build/x230-maximized/x230-maximized-bottom.rom
+sudo flashrom -p ch341a_spi -c “ZZZ” -w ~/heads/build/x86/x230-maximized/x230-maximized-bottom.rom
 ```
 
 

--- a/Installing-and-Configuring/Flashing-Guides/x230.md
+++ b/Installing-and-Configuring/Flashing-Guides/x230.md
@@ -79,7 +79,7 @@ If the files differ then try reconnecting your programmer to the SPI flash chip
 If they are the same then write `x230-flash.rom` to the SPI flash chip:
 
 ```shell
-sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x230-flash/x230-flash.rom
+sudo flashrom -p ch341a_spi -c “YYY” -w ~/heads/build/x86/x230-flash/x230-flash.rom
 ```
 
 Try to read the name on the bottom SPI flash chip. Then, connect the clip and

--- a/Installing-and-Configuring/Upgrading.md
+++ b/Installing-and-Configuring/Upgrading.md
@@ -134,7 +134,7 @@ sudo mount /dev/sdb1 ~/usb/
 Move the full Heads rom file to the usb drive and unmount the drive:
 
 ```shell
-sudo cp ~/heads/build/x230/heads.rom ~/usb/
+sudo cp ~/heads/build/x86/x230/heads.rom ~/usb/
 sudo umount /dev/sdb1
 ```
 


### PR DESCRIPTION
Since PPC64 support was added, x86 has been made the default architecture while PPC64 can be selected and is used for Talos II boards. This changed paths for:

- install -> install/x86
- packages -> packages/x86
- build -> build/x86

This PR changes those references accordingly to fix #104 per user report on slack/matrix channel.

----
Some additional cleanup:
- Also adapt porting guide to use automatic arch tuple from `$(MUSL_ARCH)`
- remove references to locally built make (was deleted a while ago)