### PR TITLE
README: point to https://osresearch.net again (DNS name renewed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Documentation for the Heads firmware project
 ===
 
-This documentation is hosted at [http://osresearch.net](https://web.archive.org/web/20230203072945/https://osresearch.net/)
+This documentation is hosted at [https://osresearch.net](https://osresearch.net/)
 
 Sources for heads are at [https://github.com/osresearch/heads/](https://github.com/osresearch/heads/)


### PR DESCRIPTION
Reverts last commit since osresearch.net is back. 
Bonus: URL points to https instead of http